### PR TITLE
Fix implicit declarations in user space code

### DIFF
--- a/tools/bootelf/bootelf.c
+++ b/tools/bootelf/bootelf.c
@@ -1,4 +1,5 @@
 
+#include <stdlib.h>
 #include <stdio.h>
 #include "elf.h"
 

--- a/tools/pmoncfg/gram.y
+++ b/tools/pmoncfg/gram.y
@@ -61,6 +61,9 @@
 
 #define	stop(s)	error(s), exit(1)
 
+void	addselect(const char *);
+void	removeselect(const char *);
+
 int	include(const char *, int);
 void	yyerror(const char *);
 int	yylex(void);

--- a/tools/srecord/srecord.c
+++ b/tools/srecord/srecord.c
@@ -3,6 +3,8 @@
  * convert binary file to Srecord format
  */
 
+#include <string.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
 
@@ -14,6 +16,7 @@ static int checksum();
 int    mask;
 int    size;
 
+int
 main(argc, argv)
 int	argc;
 char	*argv[];


### PR DESCRIPTION
By adding `#include` for system headers, and adding a few function declarations.