### PR TITLE
Don't use the `FILE *` variable in any way after fclose(3) even it fails

### DIFF
--- a/tools/pmoncfg/mkheaders.c
+++ b/tools/pmoncfg/mkheaders.c
@@ -178,8 +178,8 @@ writeit:
 	}
 	if (fprintf(fp, "%s", new_contents) < 0)
 		return (err("writ", fname, fp));
-	if (fclose(fp))
-		return (err("writ", fname, fp));
+	if (fclose(fp) == EOF)
+		return (err("writ", fname, NULL));
 	return (0);
 }
 


### PR DESCRIPTION
The code tries to **fclose(3)** the same `FILE *` variable again if the previous **fclose(3)** failed; this is wrong because the [POSIX **fclose**](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fclose.html) says:

> After the call to fclose(), any use of stream results in undefined behavior.

The result of calling **fclose(3)** again is undefined, whatever the first **fclose(3)** succeeded or not.