### PR TITLE
Fix building for Loongson 3A4000 without MIKU_SMC

### DIFF
--- a/Targets/Bonito3a4000_7a/Bonito/loongson3_def.h
+++ b/Targets/Bonito3a4000_7a/Bonito/loongson3_def.h
@@ -327,6 +327,6 @@ nop
 #define MIKU_CFG_PLL_REFC_B	24
 #define MIKU_CFG_PLL_REFC_F		(0xff << MIKU_CFG_PLL_REFC_B)
 
-#ifndef MIKU_MODEL_MAGIC
+#if defined MIKU_SMC && !defined MIKU_MODEL_MAGIC
 #error  "MIKU_MODEL_MAGIC not defined"
 #endif


### PR DESCRIPTION
`loongson3_def.h` raises an `#error` if `MIKU_MODEL_MAGIC` is not defined, even if `MIKU_SMC` isn't being set in configuration.