### PR TITLE
Add stdint.h as required by x86emu

### DIFF
--- a/sys/arch/mips/include/stdint.h
+++ b/sys/arch/mips/include/stdint.h
@@ -1,0 +1,27 @@
+#ifndef _STDINT_H
+#define _STDINT_H
+
+#ifndef __BIT_TYPES_DEFINED__
+#if defined _LP64 || defined _I32LPx || defined __LP64__ || (defined __WORDSIZE && __WORDSIZE == 64) || (_MIPS_SZLONG == 64 && _MIPS_SZINT == 32)
+typedef long int int64_t;
+typedef unsigned long int uint64_t;
+typedef int int32_t;
+typedef unsigned int uint32_t;
+typedef short int int16_t;
+typedef unsigned short int uint16_t;
+#elif defined _LLP64 || defined __LLP64__ || _MIPS_SZLONG == 32
+typedef long long int int64_t;
+typedef unsigned long long int uint64_t;
+typedef long int int32_t;
+typedef unsigned long int uint32_t;
+typedef short int int16_t;
+typedef unsigned short int uint16_t;
+#else
+#error "Type model not supported"
+#endif
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+#define __BIT_TYPES_DEFINED__
+#endif
+
+#endif


### PR DESCRIPTION
x86emu code expects that `stdint.h` being available, so building will fail if it didn't provided by the toolchain:
```
In file included from <source-path>/x86emu/int10/x86emu/include/x86emu.h:50:0,
                 from <source-path>/x86emu/int10/x86emu/src/x86emu/x86emu/x86emui.h:63,
                 from <source-path>/x86emu/int10/x86emu/src/x86emu/debug.c:40:
<source-path>/x86emu/int10/x86emu/include/x86emu/types.h:63:20: fatal error: stdint.h: No such file or directory
compilation terminated.
make[1]: *** [Makefile:535: debug.o] Error 1
```